### PR TITLE
Add smoothing operation to package and CLI

### DIFF
--- a/scripts/streamlines
+++ b/scripts/streamlines
@@ -51,6 +51,28 @@ def parse_arguments():
              'be of any file format supported by nibabel.')
     merge_subparser.set_defaults(func=streamlines.cli.merge)
 
+    # The smooth subparser.
+    smooth_subparser = subparsers.add_parser(
+        'smooth',
+        description='Smooths streamlines using a least square b-spline. The '
+                    'distance between knots controls the smoothness of the '
+                    'output streamline with larger distances being smoother.',
+        help='Smooths streamlines using a least square b-spline.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    smooth_subparser.add_argument(
+        'input', metavar='input_file', type=str,
+        help='STR The file that contains the streamlines to smooth. Can be of '
+             'any file format supported by nibabel.')
+    smooth_subparser.add_argument(
+        'output', metavar='output_file', type=str,
+        help='STR The file where the smoothed streamlines will be saved. Can '
+             'be of any file format supported by nibabel.')
+    smooth_subparser.add_argument(
+        '--knot-distance', metavar='FLOAT', type=float, default=10.0,
+        help='The distance between knots. Larger distance yield smoother '
+             'streamlines.')
+    smooth_subparser.set_defaults(func=streamlines.cli.smooth)
+
     return parser.parse_args()
 
 

--- a/streamlines/__init__.py
+++ b/streamlines/__init__.py
@@ -4,7 +4,7 @@ import collections
 import numpy as np
 import scipy.interpolate
 
-from .asarray import distance, hash, length, reorient, resample
+from .asarray import distance, hash, length, reorient, resample, smooth
 
 
 class Streamline(object):
@@ -72,6 +72,13 @@ class Streamline(object):
     def resample(self, nb_points):
         return Streamline(resample(self._points, nb_points))
 
+    def smooth(self, knot_distance=10):
+        """Smooths a streamline in place"""
+
+        self._points = smooth(self._points, knot_distance)
+
+        return self
+
 
 class Streamlines(object):
     """A sequence of dMRI streamlines"""
@@ -106,3 +113,13 @@ class Streamlines(object):
 
         if min_length is not None:
             self._items = [i for i in self._items if i.length >= min_length]
+
+        return self
+
+    def smooth(self, knot_distance=10):
+        """Smooth streamlines in place"""
+
+        for streamline in self._items:
+            streamline.smooth(knot_distance)
+
+        return self

--- a/streamlines/cli/__init__.py
+++ b/streamlines/cli/__init__.py
@@ -25,3 +25,13 @@ def merge(inputs, output):
 
     # Save the streamlines to the output file.
     save(streamlines, output)
+
+
+def smooth(input, output, **kwargs):
+
+    # Load the input streamlines using the requested parameters.
+    streamlines = load(input)
+    streamlines.smooth(**kwargs)
+
+    # Save the streamlines to the output file.
+    save(streamlines, output)

--- a/tests/test_asarray.py
+++ b/tests/test_asarray.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from streamlines.asarray import distance, length, reorient, resample
+from streamlines.asarray import distance, length, reorient, resample, smooth
 
 
 class TestAsArray(unittest.TestCase):
@@ -97,3 +97,23 @@ class TestAsArray(unittest.TestCase):
         np.testing.assert_array_almost_equal(
             resampled_streamline[1],
             [0.5, 0.0, 0.0])
+
+    def test_smooth(self):
+        """Test the smooth function"""
+
+        # Streamlines with 0 and 1 point do not change.
+        streamline = np.empty((0,3))
+        smoothed_streamline = smooth(streamline)
+        np.testing.assert_array_almost_equal(smoothed_streamline, streamline)
+
+        streamline = np.array([[0, 0, 0]])
+        smoothed_streamline = smooth(streamline)
+        np.testing.assert_array_almost_equal(smoothed_streamline, streamline)
+
+        # A straight line should remain straight.
+        x = np.linspace(0, 100, 1000)
+        yz = np.zeros((1000,))
+        streamline = np.array([x, yz, yz]).T
+
+        smoothed_streamline = smooth(streamline)
+        np.testing.assert_array_almost_equal(smoothed_streamline, streamline)


### PR DESCRIPTION
This commit adds the ability to smooth streamlines both in the python package and CLI. The smoothing is performed using b-splines and the user can modify the amount of smoothing using the knot distance option.