### PR TITLE
Fix load and save of Streamlines

### DIFF
--- a/streamlines/io/__init__.py
+++ b/streamlines/io/__init__.py
@@ -1,20 +1,34 @@
 import nibabel as nib
+import numpy as np
 
 import streamlines as sl
 
 def load(filename):
-
     # Load the input streamlines.
-    tractogram = nib.streamlines.load(filename).tractogram
+    tractogram_file = nib.streamlines.load(filename)
+    affine_to_rasmm = tractogram_file.header['voxel_to_rasmm']
+
+    tractogram = tractogram_file.tractogram
+    if not np.allclose(affine_to_rasmm, np.eye(4)):
+        inv_affine = np.linalg.inv(affine_to_rasmm)
+        tractogram = tractogram.apply_affine(inv_affine, False)
+
     streamlines = sl.Streamlines(tractogram.streamlines,
                                  tractogram.affine_to_rasmm)
 
     return streamlines
 
 
-def save(streamlines, filename):
+def save(streamlines, filename, reference_volume_shape=(1, 1, 1),
+         voxel_size=(1, 1, 1)):
 
     new_tractogram = nib.streamlines.Tractogram(
         [s.points for s in streamlines],
-        affine_to_rasmm=streamlines.affine)
-    nib.streamlines.save(new_tractogram, filename)
+         affine_to_rasmm=streamlines.affine)
+
+    hdr_dict = {'dimensions': reference_volume_shape,
+                'voxel_sizes': voxel_size,
+                'voxel_to_rasmm': streamlines.affine,
+                'voxel_order': "".join(nib.aff2axcodes(streamlines.affine))}
+    trk_file = nib.streamlines.TrkFile(new_tractogram, hdr_dict)
+    trk_file.save(filename)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,34 @@
+import unittest
+
+from tempfile import NamedTemporaryFile
+
+import numpy as np
+
+import streamlines as sl
+
+class TestIO(unittest.TestCase):
+
+    def test_save_and_load(self):
+        ''' Tests the streamlines saving function '''
+        # 9 Streamlines,?!?jedi=0,  of size 10?!? (low, high=None, *_*size=None*_*) ?!?jedi?!?
+        streamlines = np.random.randint(0, 100, size=(9, 10, 3))
+        streamlines[streamlines < 0] = 0
+
+        affine = np.array([[-1.25, 0., 0., 90.],
+                           [0., 1.25, 0., -126.],
+                           [0., 0., 1.25, -72.],
+                           [0., 0., 0., 1.]])
+
+        output = NamedTemporaryFile(mode='w', delete=True, suffix='.trk').name
+
+        # Without transformation
+        streamlines_without_affine = sl.Streamlines(streamlines)
+        sl.io.save(streamlines_without_affine, output)
+        recovered = sl.io.load(output)
+        np.testing.assert_almost_equal(streamlines, recovered)
+
+        # With transformation
+        streamlines_affine = sl.Streamlines(streamlines, affine)
+        sl.io.save(streamlines_affine, output)
+        recovered = sl.io.load(output)
+        np.testing.assert_almost_equal(streamlines, recovered, 5)


### PR DESCRIPTION
This commit fixes the load and save of streamlines. The nibabel
package loses the affine_to_rasmm transformation on save. In
order to recover the streamlines in the original space, we
read the transformation from the header, invert it and apply it.