### PR TITLE
Add reference volume dimensions and voxel size

### DIFF
--- a/scripts/streamlines
+++ b/scripts/streamlines
@@ -13,9 +13,8 @@ Streamline manipulation on the command line
 def parse_arguments():
 
     parser = argparse.ArgumentParser(description=DESCRIPTION)
-    subparsers = parser.add_subparsers()
-
-    parser.add_argument('function', type=str)
+    subparsers = parser.add_subparsers(dest='func')
+    subparsers.required = True
 
     # The filter subparser.
     filter_subparser = subparsers.add_parser(
@@ -102,6 +101,20 @@ def parse_arguments():
              'streamlines.')
     smooth_subparser.set_defaults(func=streamlines.cli.smooth)
 
+    # The transform subparser.
+    transform_subparser = subparsers.add_parser(
+        'transform',
+        description='Transforms streamlines from one file format to another.',
+        help='Transforms streamlines from one file format to another.')
+    transform_subparser.add_argument(
+        'input', metavar='input_file', type=str,
+        help='STR The file that contains the streamlines in the original '
+             'file format.')
+    transform_subparser.add_argument(
+        'output', metavar='output_file', type=str,
+        help='STR The file where to output the streamlines.')
+    transform_subparser.set_defaults(func=streamlines.cli.transform)
+
     # The view subparser.
     view_subparser = subparsers.add_parser(
         'view',
@@ -120,11 +133,10 @@ def parse_arguments():
 
 
 def main():
-
     args = parse_arguments()
     parameters = {key: value for key, value in vars(args).items() if key != 'func'}
     args.func(**parameters)
 
 
 if __name__ == '__main__':
-  main()
+    main()

--- a/scripts/streamlines
+++ b/scripts/streamlines
@@ -15,6 +15,8 @@ def parse_arguments():
     parser = argparse.ArgumentParser(description=DESCRIPTION)
     subparsers = parser.add_subparsers()
 
+    parser.add_argument('function', type=str)
+
     # The filter subparser.
     filter_subparser = subparsers.add_parser(
         'filter',
@@ -23,7 +25,7 @@ def parse_arguments():
                     '50mm using --min-length 50.',
         help='Filters streamlines based on their features.')
     filter_subparser.add_argument(
-        'input', metavar='input_file', type=str, 
+        'input', metavar='input_file', type=str,
         help='STR The file that contains the streamlines to filter. Can be of '
              'any file format supported by nibabel.')
     filter_subparser.add_argument(

--- a/scripts/streamlines_merge
+++ b/scripts/streamlines_merge
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+''' Command Line Interface for tract_merge '''
+import argparse
+from streamlines.cli.streamlines_merge import streamlines_merge
+
+if __name__ == "__main__":
+
+    # Parser
+    parser = argparse.ArgumentParser(description=("merges tracts"))
+
+    parser.add_argument('tracts_to_merge', type=str, nargs='+')
+
+    parser.add_argument('outfile', type=str)
+
+    args = parser.parse_args()
+
+    streamlines_merge(args.tracts_to_merge, args.outfile)

--- a/streamlines/__init__.py
+++ b/streamlines/__init__.py
@@ -145,7 +145,8 @@ class Streamline(object):
 class Streamlines(object):
     """A sequence of diffusion MRI streamlines"""
 
-    def __init__(self, iterable=None, affine=np.eye(4)):
+    def __init__(self, iterable=None, affine=np.eye(4),
+                 reference_volume_shape=(1, 1, 1), voxel_sizes=(1, 1, 1)):
         """Sequence of diffusion MRI streamlines
 
            An instance of the Streamlines class represents a group of diffusion
@@ -157,10 +158,15 @@ class Streamlines(object):
                     to a Streamline instance, i.e. it must be convertible to a
                     (N, 3) array of float. See the Streamline class for more
                     details.
-
+                affine (optional): Transformation from current space to rasmm.
+                reference_volume_shape (optional): Size of the volume in which
+                    the streamlines will be displayed. Needed by trackvis.
+                voxel_size (optional): Voxel size of the volume in which the
+                    streamlines will be displayed. Needed by trackvis.
         """
-
         self.affine = affine
+        self.reference_volume_shape = reference_volume_shape
+        self.voxel_sizes = voxel_sizes
 
         self._items = []
         if iterable is not None:

--- a/streamlines/cli/__init__.py
+++ b/streamlines/cli/__init__.py
@@ -32,7 +32,7 @@ def merge(inputs, output):
 
     # Load all the input streamlines and merge them.
     streamlines_list = [load(i) for i in inputs]
-    streamlines = reduce(operator.iadd, streamlines_list)    
+    streamlines = reduce(operator.iadd, streamlines_list)
 
     # Save the streamlines to the output file.
     save(streamlines, output)
@@ -55,6 +55,10 @@ def smooth(input, output, **kwargs):
     # Save the streamlines to the output file.
     save(streamlines, output)
 
+def transform(input, output):
+    """Transforms streamlines from one fileformat to another"""
+    streamlines = load(input)
+    save(streamlines, output)
 
 def view(filename):
     """View streamlines in interactive window"""

--- a/streamlines/cli/streamlines_merge.py
+++ b/streamlines/cli/streamlines_merge.py
@@ -1,0 +1,13 @@
+from .. import io, Streamlines
+
+def streamlines_merge(streamlines_to_merge, outfile):
+
+    streamlines = [io.load(tract_file) for tract_file in streamlines_to_merge]
+
+    merged = streamlines[0]
+
+    for streamline in streamlines[1:]:
+        merged += streamline
+
+    io.save(merged, outfile)
+

--- a/streamlines/io/__init__.py
+++ b/streamlines/io/__init__.py
@@ -9,8 +9,13 @@ def load(filename):
     # Load the input streamlines.
     tractogram_file = nib.streamlines.load(filename)
     affine_to_rasmm = tractogram_file.header['voxel_to_rasmm']
-    reference_volume_shape = tractogram_file.header['dimensions']
-    voxel_sizes = tractogram_file.header['voxel_sizes']
+
+    if filename.endswith('trk'):
+        reference_volume_shape = tractogram_file.header['dimensions']
+        voxel_sizes = tractogram_file.header['voxel_sizes']
+    else:
+        reference_volume_shape = (1, 1, 1)
+        voxel_sizes = (1, 1, 1)
 
     tractogram = tractogram_file.tractogram
     if not np.allclose(affine_to_rasmm, np.eye(4)):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -18,6 +18,9 @@ class TestIO(unittest.TestCase):
                            [0., 1.25, 0., -126.],
                            [0., 0., 1.25, -72.],
                            [0., 0., 0., 1.]])
+        
+        voxel_sizes = [0.1, 0.2, 0.3]
+        ref_volume_shape = [100, 100, 100]
 
         output = NamedTemporaryFile(mode='w', delete=True, suffix='.trk').name
 
@@ -32,3 +35,12 @@ class TestIO(unittest.TestCase):
         sl.io.save(streamlines_affine, output)
         recovered = sl.io.load(output)
         np.testing.assert_almost_equal(streamlines, recovered, 5)
+
+        # With metadata
+        streamlines_affine = sl.Streamlines(streamlines, affine,
+                                            ref_volume_shape, voxel_sizes)
+        sl.io.save(streamlines_affine, output)
+        recovered = sl.io.load(output)
+        np.testing.assert_equal(recovered.reference_volume_shape,
+                                ref_volume_shape)
+        np.testing.assert_almost_equal(recovered.voxel_sizes, voxel_sizes)


### PR DESCRIPTION
This commit changes the object Streamlines in order to add the
properties 'reference_volume_size' and 'voxel_sizes'. These two
parameters are used by trackvis in order to correctly visualize the
streamlines.