### PR TITLE
Added 'iO' as a package in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as f:
 setup(
     name='streamlines',
     version='0.0.0',
-    packages=['streamlines'],
+    packages=['streamlines', 'streamlines.io'],
     scripts=['scripts/streamlines'],
     url='https://github.com/sdeslauriers/streamlines',
     license='GPL-3.0',


### PR DESCRIPTION
It is not possible to import "streamlines.io" after a clean install since it is not listed as a "package" in the setup.py. This commit fixes such problem.