### PR TITLE
ENH: add support to save streamlines in .tck format

### DIFF
--- a/scripts/streamlines
+++ b/scripts/streamlines
@@ -33,7 +33,8 @@ def parse_arguments():
 def main():
 
     args = parse_arguments()
-    parameters = {k: v for k, v in vars(args).items() if k != 'func'}
+    to_ignore = ['func', 'subcommand']
+    parameters = {k: v for k, v in vars(args).items() if k not in to_ignore}
     args.func(**parameters)
 
 

--- a/streamlines/__init__.py
+++ b/streamlines/__init__.py
@@ -193,8 +193,16 @@ class Streamlines(AffineTransformable):
         for streamline, new_points in zip(self, points):
             streamline._points = new_points
 
-    def __iadd__(self, other: 'Streamlines'):
-        self._items += other._items
+    def __iadd__(self, other):
+        if isinstance(other, Streamlines):
+            self._items += other._items
+        elif isinstance(other, Streamline):
+            self._items.append(other)
+        else:
+            raise TypeError(
+                f'A value of type {type(other)} cannot be concatenated with '
+                f'streamlines.')
+
         return self
 
     def __contains__(self, streamline):

--- a/streamlines/cli/commands/convert.py
+++ b/streamlines/cli/commands/convert.py
@@ -1,0 +1,31 @@
+from streamlines.io import load
+from streamlines.io import save
+
+
+def add_parser(subparsers):
+
+    convert_subparser = subparsers.add_parser(
+        'convert',
+        description='Converts a streamline file from one format to another.')
+    convert_subparser.add_argument(
+        'input_filename', metavar='input_file', type=str,
+        help='STR The file that contains the streamlines. Can be of '
+             'any file format supported by nibabel.')
+    convert_subparser.add_argument(
+        'output_filename', metavar='output_file', type=str,
+        help='STR The name of the output file. Can be of any file format '
+             'supported by nibabel.')
+    convert_subparser.set_defaults(func=convert)
+
+
+def convert(input_filename, output_filename):
+    """Converts a streamlines file from one format to another
+
+    Args:
+        input_filename: The file to convert.
+        output_filename: The output filename.
+    """
+
+    # Let load and save do all the work.
+    streamlines = load(input_filename)
+    save(streamlines, output_filename)

--- a/streamlines/cli/commands/filter.py
+++ b/streamlines/cli/commands/filter.py
@@ -12,11 +12,11 @@ def add_parser(subparsers):
                     '50mm using --min-length 50.',
         help='Filters streamlines based on their features.')
     filter_subparser.add_argument(
-        'input', metavar='input_file', type=str,
+        'input_filename', metavar='input_file', type=str,
         help='STR The file that contains the streamlines to filter. Can be of '
              'any file format supported by nibabel.')
     filter_subparser.add_argument(
-        'output', metavar='output_file', type=str,
+        'output_filename', metavar='output_file', type=str,
         help='STR The file where the filtered streamlines will be saved. Can '
              'be of any file format supported by nibabel.')
     filter_subparser.add_argument(

--- a/streamlines/cli/commands/info.py
+++ b/streamlines/cli/commands/info.py
@@ -10,24 +10,24 @@ def add_parser(subparsers):
         'info',
         description='Prints information about streamlines in a file.')
     info_subparser.add_argument(
-        'input', metavar='input_file', type=str,
+        'input_filename', metavar='input_file', type=str,
         help='STR The file that contains the streamlines. Can be of '
              'any file format supported by nibabel.')
     info_subparser.set_defaults(func=info)
 
 
-def info(streamlines_filename):
+def info(input_filename):
     """Print information about a streamlines file
 
     Prints the number of streamlines in the file and the mean length of the
     streamlines.
 
     Args:
-        streamlines_filename: The file whose info is printed.
+        input_filename: The file whose info is printed.
     """
 
     # Load the input streamlines using the requested parameters.
-    streamlines = load(streamlines_filename)
+    streamlines = load(input_filename)
 
     # Print info about the streamlines.
     out = ''

--- a/streamlines/cli/commands/merge.py
+++ b/streamlines/cli/commands/merge.py
@@ -14,21 +14,21 @@ def add_parser(subparsers):
                     'exist.',
         help='Merges several streamline files into one.')
     merge_subparser.add_argument(
-        'inputs', metavar='input_files', nargs='+',
+        'input_filenames', metavar='input_files', nargs='+',
         help='STR STR ... The files to be merged. Can be of any file format '
              'supported by nibabel.')
     merge_subparser.add_argument(
-        'output', metavar='output_file', type=str,
+        'output_filename', metavar='output_file', type=str,
         help='STR The file where the merged streamlines will be saved. Can '
              'be of any file format supported by nibabel.')
     merge_subparser.set_defaults(func=merge)
 
 
-def merge(inputs, output):
+def merge(input_filenames, output_filename):
 
     # Load all the input streamlines and merge them.
-    streamlines_list = [load(i) for i in inputs]
+    streamlines_list = [load(i) for i in input_filenames]
     streamlines = reduce(iadd, streamlines_list)
 
     # Save the streamlines to the output file.
-    save(streamlines, output)
+    save(streamlines, output_filename)

--- a/streamlines/cli/commands/reorient.py
+++ b/streamlines/cli/commands/reorient.py
@@ -15,11 +15,11 @@ def add_parser(subparsers):
         help='Reorients streamlines of a bundle.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     reorient_subparser.add_argument(
-        'input', metavar='input_file', type=str,
+        'input_filename', metavar='input_file', type=str,
         help='STR The file that contains the streamlines to reorient. Can be '
              'of any file format supported by nibabel.')
     reorient_subparser.add_argument(
-        'output', metavar='output_file', type=str,
+        'output_filename', metavar='output_file', type=str,
         help='STR The file where the reoriented streamlines will be saved. '
              'Can be of any file format supported by nibabel.')
 

--- a/streamlines/cli/commands/smooth.py
+++ b/streamlines/cli/commands/smooth.py
@@ -15,11 +15,11 @@ def add_parser(subparsers):
         help='Smooths streamlines using a least square b-spline.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     smooth_subparser.add_argument(
-        'input', metavar='input_file', type=str,
+        'input_filename', metavar='input_file', type=str,
         help='STR The file that contains the streamlines to smooth. Can be of '
              'any file format supported by nibabel.')
     smooth_subparser.add_argument(
-        'output', metavar='output_file', type=str,
+        'output_filename', metavar='output_file', type=str,
         help='STR The file where the smoothed streamlines will be saved. Can '
              'be of any file format supported by nibabel.')
     smooth_subparser.add_argument(

--- a/streamlines/io/__init__.py
+++ b/streamlines/io/__init__.py
@@ -1,3 +1,5 @@
+from os.path import splitext
+
 import nibabel as nib
 import numpy as np
 
@@ -20,7 +22,7 @@ _ras_mm = CoordinateSystem(
 def load(filename: str):
     """Loads the streamlines contained in a file
 
-    Loads the streamlines contained in a .trk file. The streamlines are
+    Loads the streamlines contained in a file. The streamlines are
     always loaded in a native RAS coordinate system. If the voxel_to_rasmm
     affine transform is present in the header, it is also loaded with
     the streamlines. This allows the transformation to voxel space using the
@@ -150,5 +152,14 @@ def save(streamlines, filename):
                 'voxel_sizes': voxel_sizes,
                 'voxel_to_rasmm': affine,
                 'voxel_order': "".join(nib.aff2axcodes(affine))}
-    trk_file = nib.streamlines.TrkFile(new_tractogram, hdr_dict)
-    trk_file.save(filename)
+
+    # Choose the file type from the extension.
+    _, extension = splitext(filename)
+    if extension == '.trk':
+        tractogram_file = nib.streamlines.TrkFile
+    elif extension == '.tck':
+        tractogram_file = nib.streamlines.TckFile
+    else:
+        raise ValueError(f'Unknown streamlines file format {extension}.')
+    tractogram_file = tractogram_file(new_tractogram, hdr_dict)
+    tractogram_file.save(filename)

--- a/streamlines/io/__init__.py
+++ b/streamlines/io/__init__.py
@@ -1,4 +1,5 @@
 from os.path import splitext
+import warnings
 
 import nibabel as nib
 import numpy as np
@@ -36,9 +37,25 @@ def load(filename: str):
     # Load the input streamlines.
     tractogram_file = nib.streamlines.load(filename)
     header = tractogram_file.header
-    affine_to_rasmm = header['voxel_to_rasmm']
-    voxel_sizes = header['voxel_sizes']
-    shape = header['dimensions']
+
+    if 'voxel_to_rasmm' in header:
+        affine_to_rasmm = header['voxel_to_rasmm']
+    else:
+        affine_to_rasmm = np.eye(4)
+
+    if 'voxel_sizes' in header:
+        voxel_sizes = header['voxel_sizes']
+    else:
+        warnings.warn('The file {filename} does not contain voxel size '
+                      'information. Setting voxel size to 1.')
+        voxel_sizes = [1, 1, 1]
+
+    if 'dimensions' in header:
+        shape = header['dimensions']
+    else:
+        warnings.warn('The file {filename} does not contain image dimension '
+                      'information. Setting image dimensions to (1, 1, 1).')
+        shape = (1, 1, 1)
 
     # If there is a transform to RAS, invert it to get the transform to
     # voxel space.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,11 +5,13 @@ import unittest
 import numpy as np
 
 from streamlines import Streamlines
+from streamlines.cli.commands.convert import convert
 from streamlines.cli.commands.reorient import reorient
 from streamlines.cli.commands.filter import filter
 from streamlines.cli.commands.info import info
 from streamlines.cli.commands.merge import merge
-from streamlines.io import load, save
+from streamlines.io import load
+from streamlines.io import save
 
 
 class TestCLI(unittest.TestCase):
@@ -67,6 +69,16 @@ class TestCLI(unittest.TestCase):
 
         cls.test_dir.cleanup()
 
+    def test_convert(self):
+        """Test the convert command of the CLI"""
+
+        # Simply try to convert the file. Nothing should happen.
+        input_filename = os.path.join(self.test_dir.name, 'short.trk')
+        output_filename = os.path.join(self.test_dir.name, 'short.tck')
+        convert(input_filename, output_filename)
+        streamlines = load(output_filename)
+        self.assertEqual(len(streamlines), 3)
+
     def test_filter(self):
         """Test the filter command of the CLI"""
 
@@ -98,7 +110,7 @@ class TestCLI(unittest.TestCase):
         streamlines = load(output)
         self.assertEqual(len(streamlines), 4)
 
-        # Merging the shord and empty files should yield 3 streamlines.
+        # Merging the short and empty files should yield 3 streamlines.
         inputs = [os.path.join(self.test_dir.name, i)
                   for i in ['short.trk', 'empty.trk']]
         output = os.path.join(self.test_dir.name, 'test-merge-2.trk')


### PR DESCRIPTION
The only format currently supported by the streamlines package is .trk.
To view streamlines in mrview, it would be convenient to be able to save
them in .tck.

This commit adds support for saving streamlines in the .tck format.